### PR TITLE
fix `split` and add example

### DIFF
--- a/examples/strong.js
+++ b/examples/strong.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const {first, second, both, split} = require('../fantasy-profunctors');
+const {identity} = require('fantasy-combinators');
+const {Tuple} = require('fantasy-tuples');
+
+const toUpper = x => x.toUpperCase();
+const add = y => x => x + y;
+
+
+console.log('#first', first(toUpper)(Tuple('first', 'second')));        // => Tuple('FIRST', 'second')
+console.log('#second', second(toUpper)(Tuple('first', 'second')));      // => Tuple('first', 'SECOND')
+console.log('#both', both(toUpper, toUpper)(Tuple('first', 'second'))); // => Tuple('FIRST', 'SECOND')
+console.log('#split', split(toUpper, add('___'))('first'));             // => Tuple('FIRST', 'first___')

--- a/src/strong.js
+++ b/src/strong.js
@@ -10,8 +10,8 @@ const { map: mapʹ } = require('./profunctor');
 // Function combinators
 
 const first = x => {
-    return isFunction(x.first) 
-         ? x.first() 
+    return isFunction(x.first)
+         ? x.first()
          : y => Tuple(x(y._1), y._2);
 };
 
@@ -23,7 +23,7 @@ const second = x => {
 
 const both = curry((x, y) => compose(first(x))(second(y)));
 
-const split = curry((l, r) => compose(mapʹ(a => Tuple(a, a), identity))(both(l, r)));
+const split = curry((l, r) => compose(both(l, r))(mapʹ(a => Tuple(a, a), identity)));
 
 module.exports = { first
                  , second


### PR DESCRIPTION
This PR adds some examples for `first`, `second`, `both` and `split` and it may fixes the implementation of `split`.

I'm not entirely sure, but I think the order of the composed functions in `split` should be reversed.
The implementation of `split` in [`flunc/optics`](https://github.com/flunc/optics/blob/master/src/Internal/Profunctor/Class/Strong.js#L28) is also like the one in this PR.
